### PR TITLE
[CWP-64] RSS feed

### DIFF
--- a/includes/gating/functions.php
+++ b/includes/gating/functions.php
@@ -115,7 +115,7 @@ function maybe_restrict_content( string $content ) : string {
 
 		case 'gate-tagged-blocks':
 			// Restrict some part of this content. (split content).
-			$public_content  = '<p>' . esc_html__( 'This article is monetized and some content is for members only.', 'coil-web-monetization' ) . '</p>';
+			$public_content = '<p>' . esc_html__( 'This article is monetized and some content is for members only.', 'coil-web-monetization' ) . '</p>';
 
 			if ( ! is_feed() ) {
 				$public_content .= $content;


### PR DESCRIPTION
RSS: fix visibility of 'split content' content in RSS feeds.

The implementation to reveal content is carried out client-side, and we can't
do that in a RSS feed. 'Split content' and 'members only' content does not
appear in the RSS feed, and hopefully this will cause people to go to the
actual website and view the content in situ (with Coil!).

(Actually, this will apply to all kinds of feed output from WordPress, not strictly just RSS, but it is the same code path -- just a different XML output).