### PR TITLE
css-learn-more

### DIFF
--- a/includes/settings/functions.php
+++ b/includes/settings/functions.php
@@ -297,7 +297,7 @@ function coil_global_settings_advanced_config_render_callback() {
 	printf(
 		/* translators: 1) HTML link open tag, 2) HTML link close tag, 3) HTML link open tag, 4) HTML link close tag. */
 		esc_html__( 'Enter the CSS selectors used in your theme that could include gated content. Most themes use the pre-filled CSS selectors. (%1$sLearn more%2$s)', 'coil-web-monetization' ),
-		sprintf( '<a href="%s" target="_blank">', esc_url( '#' ) ),
+		sprintf( '<a href="%s" target="_blank">', esc_url( 'https://help.coil.com/for-creators/wordpress-plugin#everyone-no-one-can-see-my-monetized-content-why' ) ),
 		'</a>'
 	);
 


### PR DESCRIPTION
Updated the Learn More link in the CSS Selectors section to point to Coil help doc. The Coil help doc isn't live yet, so the URL itself is broken.