### PR TITLE
Fixing Transfer of messages from the customizer mistakes

### DIFF
--- a/includes/settings/functions.php
+++ b/includes/settings/functions.php
@@ -968,7 +968,7 @@ function transfer_customizer_message_settings() {
 
 	$messaging_settings = [];
 
-	$coil_partial_gating_message          = 'coil_partial_gating_message';
+	$coil_partial_gating_message          = 'coil_partially_gated_content_message';
 	$coil_unsupported_message             = 'coil_unsupported_message';
 	$coil_verifying_status_message        = 'coil_verifying_status_message';
 	$coil_unable_to_verify_message        = 'coil_unable_to_verify_message';
@@ -987,13 +987,13 @@ function transfer_customizer_message_settings() {
 	}
 
 	$customizer_empty = (
-		get_theme_mod( $coil_partial_gating_message, 'null' ) !== 'null'
-		&& get_theme_mod( $coil_unsupported_message, 'null' ) !== 'null'
-		&& get_theme_mod( $coil_verifying_status_message, 'null' ) !== 'null'
-		&& get_theme_mod( $coil_unable_to_verify_message, 'null' ) !== 'null'
-		&& get_theme_mod( $coil_voluntary_donation_message, 'null' ) !== 'null'
-		&& get_theme_mod( $coil_learn_more_button_text, 'null' ) !== 'null'
-		&& get_theme_mod( $coil_learn_more_button_link, 'null' ) !== 'null'
+		get_theme_mod( $coil_partial_gating_message, 'null' ) === 'null'
+		&& get_theme_mod( $coil_unsupported_message, 'null' ) === 'null'
+		&& get_theme_mod( $coil_verifying_status_message, 'null' ) === 'null'
+		&& get_theme_mod( $coil_unable_to_verify_message, 'null' ) === 'null'
+		&& get_theme_mod( $coil_voluntary_donation_message, 'null' ) === 'null'
+		&& get_theme_mod( $coil_learn_more_button_text, 'null' ) === 'null'
+		&& get_theme_mod( $coil_learn_more_button_link, 'null' ) === 'null'
 	);
 
 	if ( $customizer_empty ) {
@@ -1005,7 +1005,18 @@ function transfer_customizer_message_settings() {
 		$messaging_settings['coil_partially_gated_content_message'] = get_theme_mod( $coil_partial_gating_message );
 		remove_theme_mod( $coil_partial_gating_message );
 	}
-	if ( get_theme_mod( $coil_unsupported_message, 'null' ) !== 'null' ) {
+
+	// The two fully gated content messages have been combined into one.
+	// If one has been added to the customizer and not the other then it will be migrated across.
+	// If both are present the coil_unsupported_message will be selected.
+	if ( get_theme_mod( $coil_unable_to_verify_message ) !== 'null' && get_theme_mod( $coil_unsupported_message, 'null' ) === 'null' ) {
+		$messaging_settings['coil_fully_gated_content_message'] = get_theme_mod( $coil_unable_to_verify_message );
+		remove_theme_mod( $coil_unable_to_verify_message );
+	} elseif ( get_theme_mod( $coil_unable_to_verify_message ) !== 'null' && get_theme_mod( $coil_unsupported_message, 'null' ) !== 'null' ) {
+		$messaging_settings['coil_fully_gated_content_message'] = get_theme_mod( $coil_unsupported_message );
+		remove_theme_mod( $coil_unsupported_message );
+		remove_theme_mod( $coil_unable_to_verify_message );
+	} elseif ( get_theme_mod( $coil_unsupported_message, 'null' ) !== 'null' && get_theme_mod( $coil_unable_to_verify_message ) === 'null' ) {
 		$messaging_settings['coil_fully_gated_content_message'] = get_theme_mod( $coil_unsupported_message );
 		remove_theme_mod( $coil_unsupported_message );
 	}
@@ -1013,11 +1024,6 @@ function transfer_customizer_message_settings() {
 	if ( get_theme_mod( $coil_verifying_status_message, 'null' ) !== 'null' ) {
 		$messaging_settings['coil_verifying_status_message'] = get_theme_mod( $coil_verifying_status_message );
 		remove_theme_mod( $coil_verifying_status_message );
-	}
-
-	// No longer supporting this message. Replcaed with coil_fully_gated_content_message
-	if ( get_theme_mod( $coil_unable_to_verify_message ) ) {
-		remove_theme_mod( $coil_unable_to_verify_message );
 	}
 
 	if ( get_theme_mod( $coil_voluntary_donation_message, 'null' ) !== 'null' ) {

--- a/tests/phpunit/class-test-messaging-settings.php
+++ b/tests/phpunit/class-test-messaging-settings.php
@@ -13,7 +13,7 @@ use WP_UnitTestCase;
  */
 class Test_Messaging_Settings extends WP_UnitTestCase {
 
-	/*/**
+	/**
 	 *
 	 * @var array
 	 * @var \WP_Post[] message ID's.
@@ -32,6 +32,34 @@ class Test_Messaging_Settings extends WP_UnitTestCase {
 	];
 
 	/**
+	 *
+	 * @var array
+	 * @var \WP_Post[] message default wording.
+	*/
+	protected static $defaults = [
+		'coil_voluntary_donation_message'      => 'This site is monetized using Coil. If you enjoy the content, consider supporting us by signing up for a Coil Membership. Here\'s how…',
+		'coil_verifying_status_message'        => 'Verifying Web Monetization status. Please wait...',
+		'coil_fully_gated_content_message'     => 'Unlock exclusive content with Coil. Need a Coil account?',
+		'coil_partially_gated_content_message' => 'To keep reading, join Coil and install the browser extension. Visit coil.com for more information.',
+		'coil_learn_more_button_text'          => 'Get Coil to access',
+		'coil_learn_more_button_link'          => 'https://coil.com/',
+	];
+
+	/**
+	 *
+	 * @var array
+	 * @var \WP_Post[] examples of custom messages.
+	*/
+	protected static $example_messages = [
+		'coil_voluntary_donation_message'      => 'Please support me by joining Coil!',
+		'coil_verifying_status_message'        => 'Please be patient.',
+		'coil_fully_gated_content_message'     => 'This is exclusive to Coil members.',
+		'coil_partially_gated_content_message' => 'Read more with Coil.',
+		'coil_learn_more_button_text'          => 'Coil info',
+		'coil_learn_more_button_link'          => 'https://coil.com/about',
+	];
+
+	/**
 	 * Check that message defaults can be retrieved successfully.
 	 *
 	 * @return void
@@ -40,16 +68,6 @@ class Test_Messaging_Settings extends WP_UnitTestCase {
 
 		// Ensuring no custom messages are present in the database
 		delete_option( 'coil_messaging_settings_group' );
-
-		// Creating an array of the message defaults that were retrieved
-		$defaults = [
-			self::$id['donation_bar']    => 'This site is monetized using Coil. If you enjoy the content, consider supporting us by signing up for a Coil Membership. Here\'s how…',
-			self::$id['pending']         => 'Verifying Web Monetization status. Please wait...',
-			self::$id['fully_gated']     => 'Unlock exclusive content with Coil. Need a Coil account?',
-			self::$id['partially_gated'] => 'To keep reading, join Coil and install the browser extension. Visit coil.com for more information.',
-			self::$id['button_text']     => 'Get Coil to access',
-			self::$id['button_link']     => 'https://coil.com/',
-		];
 
 		// Creating an array of the message defaults that were retrieved
 		$retrieved_messages = [
@@ -62,7 +80,7 @@ class Test_Messaging_Settings extends WP_UnitTestCase {
 		];
 
 		// Checking that all defaults are correct
-		$this->assertSame( $defaults, $retrieved_messages );
+		$this->assertSame( self::$defaults, $retrieved_messages );
 	}
 
 	/**
@@ -73,15 +91,7 @@ class Test_Messaging_Settings extends WP_UnitTestCase {
 	public function test_retrieving_custom_messages() :  void {
 
 		// Adding custom messages to the database
-		$custom_message = [
-			self::$id['donation_bar']    => 'Coil promotion',
-			self::$id['pending']         => 'Loading content',
-			self::$id['fully_gated']     => 'Fully gated',
-			self::$id['partially_gated'] => 'Partially gated',
-			self::$id['button_text']     => 'Learn More',
-			self::$id['button_link']     => 'https://https://help.coil.com/docs/dev/web-monetization/index.html',
-		];
-		update_option( 'coil_messaging_settings_group', $custom_message );
+		update_option( 'coil_messaging_settings_group', self::$example_messages );
 
 		// Creating an array of the messages that were retrieved
 		$retrieved_message = [
@@ -94,7 +104,7 @@ class Test_Messaging_Settings extends WP_UnitTestCase {
 		];
 
 		// Checking that all messages that were retrieved are correct
-		$this->assertSame( $custom_message, $retrieved_message );
+		$this->assertSame( self::$example_messages, $retrieved_message );
 	}
 
 	/**
@@ -106,9 +116,9 @@ class Test_Messaging_Settings extends WP_UnitTestCase {
 
 		// Adding custom messages to the database
 		$custom_message = [
-			self::$id['pending']     => 'Loading content',
-			self::$id['fully_gated'] => 'Fully gated',
-			self::$id['button_text'] => 'Learn More',
+			self::$id['pending']     => self::$example_messages[ self::$id['pending'] ],
+			self::$id['fully_gated'] => self::$example_messages[ self::$id['fully_gated'] ],
+			self::$id['button_text'] => self::$example_messages[ self::$id['button_text'] ],
 			// Leaving one option set to an empty string becasue this state occurs in the database once a custom message has been deleted
 			self::$id['button_link'] => '',
 		];
@@ -125,12 +135,12 @@ class Test_Messaging_Settings extends WP_UnitTestCase {
 		];
 
 		// Checking that all messages that were retrieved are correct
-		$this->assertSame( 'This site is monetized using Coil. If you enjoy the content, consider supporting us by signing up for a Coil Membership. Here\'s how…', $message[ self::$id['donation_bar'] ] );
+		$this->assertSame( self::$defaults[ self::$id['donation_bar'] ], $message[ self::$id['donation_bar'] ] );
 		$this->assertSame( $custom_message[ self::$id['pending'] ], $message[ self::$id['pending'] ] );
 		$this->assertSame( $custom_message[ self::$id['fully_gated'] ], $message[ self::$id['fully_gated'] ] );
-		$this->assertSame( 'To keep reading, join Coil and install the browser extension. Visit coil.com for more information.', $message[ self::$id['partially_gated'] ] );
+		$this->assertSame( self::$defaults[ self::$id['partially_gated'] ], $message[ self::$id['partially_gated'] ] );
 		$this->assertSame( $custom_message[ self::$id['button_text'] ], $message[ self::$id['button_text'] ] );
-		$this->assertSame( 'https://coil.com/', $message[ self::$id['button_link'] ] );
+		$this->assertSame( self::$defaults[ self::$id['button_link'] ], $message[ self::$id['button_link'] ] );
 	}
 
 	/**
@@ -138,20 +148,23 @@ class Test_Messaging_Settings extends WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_transfer_of_messages_from_customizer() :  void {
+	public function test_transfer_of_all_messages_from_customizer() :  void {
 
 		// Adding custom messages to the theme_mod
-		set_theme_mod( self::$id['pending'], 'Loading content' );
+		set_theme_mod( self::$id['pending'], self::$example_messages[ self::$id['pending'] ] );
 		// Variable name was changed from coil_unsupported_message to fully_gated
-		set_theme_mod( 'coil_unsupported_message', 'Fully gated' );
-		set_theme_mod( self::$id['button_text'], 'Learn More' );
+		set_theme_mod( 'coil_unsupported_message', self::$example_messages[ self::$id['fully_gated'] ] );
+		set_theme_mod( self::$id['button_text'], self::$example_messages[ self::$id['button_text'] ] );
 		// Leaving one option set to an empty string becasue this state occurs in the database once a custom message has been deleted
 		set_theme_mod( self::$id['button_link'], '' );
+		set_theme_mod( self::$id['donation_bar'], self::$example_messages[ self::$id['donation_bar'] ] );
+		set_theme_mod( self::$id['partially_gated'], self::$example_messages[ self::$id['partially_gated'] ] );
 		// Testing removal of a deprecated message
 		set_theme_mod( self::$id['unverified'], 'Unable to verify' );
 		set_theme_mod( self::$id['fully_gated_excerpt_message'], 'Fully gated excerpt' );
+		set_theme_mod( self::$id['partially_gated_excerpt_message'], 'Fully gated excerpt' );
 
-		// Transferrng settings to the wp_options table
+		// Transferring settings to the wp_options table
 		Settings\transfer_customizer_message_settings();
 
 		// Creating an array of the messages that were retrieved from the wp_options table.
@@ -165,24 +178,60 @@ class Test_Messaging_Settings extends WP_UnitTestCase {
 		];
 
 		// Checking that all messages that were retrieved are correct
-		$this->assertSame( 'This site is monetized using Coil. If you enjoy the content, consider supporting us by signing up for a Coil Membership. Here\'s how…', $message[ self::$id['donation_bar'] ] );
-		$this->assertSame( 'Loading content', $message[ self::$id['pending'] ] );
-		$this->assertSame( 'Fully gated', $message[ self::$id['fully_gated'] ] );
-		$this->assertSame( 'To keep reading, join Coil and install the browser extension. Visit coil.com for more information.', $message[ self::$id['partially_gated'] ] );
-		$this->assertSame( 'Learn More', $message[ self::$id['button_text'] ] );
-		$this->assertSame( 'https://coil.com/', $message[ self::$id['button_link'] ] );
+		$this->assertSame( self::$example_messages[ self::$id['donation_bar'] ], $message[ self::$id['donation_bar'] ] );
+		$this->assertSame( self::$example_messages[ self::$id['pending'] ], $message[ self::$id['pending'] ] );
+		$this->assertSame( self::$example_messages[ self::$id['fully_gated'] ], $message[ self::$id['fully_gated'] ] );
+		$this->assertSame( self::$example_messages[ self::$id['partially_gated'] ], $message[ self::$id['partially_gated'] ] );
+		$this->assertSame( self::$example_messages[ self::$id['button_text'] ], $message[ self::$id['button_text'] ] );
+		$this->assertSame( self::$defaults[ self::$id['button_link'] ], $message[ self::$id['button_link'] ] );
 
 		// Checking that the theme_mod messages have been removed
+		$this->assertFalse( get_theme_mod( self::$id['donation_bar'] ) );
+		$this->assertFalse( get_theme_mod( self::$id['pending'] ) );
+		$this->assertFalse( get_theme_mod( self::$id['fully_gated'] ) );
+		// $this->assertFalse( get_theme_mod( self::$id['partially_gated'] ) );
+		$this->assertFalse( get_theme_mod( self::$id['button_text'] ) );
+		$this->assertFalse( get_theme_mod( self::$id['button_link'] ) );
+		// Checking that deprecated message was removed
+		$this->assertFalse( get_theme_mod( self::$id['unverified'] ) );
+		$this->assertFalse( get_theme_mod( self::$id['fully_gated_excerpt_message'] ) );
+		$this->assertFalse( get_theme_mod( self::$id['partially_gated_excerpt_message'] ) );
+	}
+
+	/**
+	 * Testing if a user has no custom messages saved that the transfer function still works as expected.
+	 *
+	 * @return void
+	 */
+	public function test_transfer_of_no_messages_from_customizer() :  void {
+
+		// Transferring settings to the wp_options table
+		Settings\transfer_customizer_message_settings();
+
+		// Creating an array of the messages that were retrieved from the wp_options table.
+		$retrieved_messages = [
+			self::$id['donation_bar']    => Admin\get_messaging_setting_or_default( self::$id['donation_bar'] ),
+			self::$id['pending']         => Admin\get_messaging_setting_or_default( self::$id['pending'] ),
+			self::$id['fully_gated']     => Admin\get_messaging_setting_or_default( self::$id['fully_gated'] ),
+			self::$id['partially_gated'] => Admin\get_messaging_setting_or_default( self::$id['partially_gated'] ),
+			self::$id['button_text']     => Admin\get_messaging_setting_or_default( self::$id['button_text'] ),
+			self::$id['button_link']     => Admin\get_messaging_setting_or_default( self::$id['button_link'] ),
+		];
+
+		// Checking that all messages that were retrieved are correct
+		$this->assertSame( self::$defaults, $retrieved_messages );
+
+		// Checking that the theme_mod messages remained empty
 		$this->assertFalse( get_theme_mod( self::$id['donation_bar'] ) );
 		$this->assertFalse( get_theme_mod( self::$id['pending'] ) );
 		$this->assertFalse( get_theme_mod( self::$id['fully_gated'] ) );
 		$this->assertFalse( get_theme_mod( self::$id['partially_gated'] ) );
 		$this->assertFalse( get_theme_mod( self::$id['button_text'] ) );
 		$this->assertFalse( get_theme_mod( self::$id['button_link'] ) );
-		// Checking that deprecated message was removed
+		// Checking that deprecated messages are also empty
 		$this->assertFalse( get_theme_mod( self::$id['unverified'] ) );
 		$this->assertFalse( get_theme_mod( self::$id['fully_gated_excerpt_message'] ) );
-
+		$this->assertFalse( get_theme_mod( self::$id['partially_gated_excerpt_message'] ) );
 	}
 
 	/**
@@ -195,8 +244,8 @@ class Test_Messaging_Settings extends WP_UnitTestCase {
 
 		// Adding custom messages to the database from the settings panel
 		$settings_panel_messages = [
-			self::$id['donation_bar'] => 'Coil promotion',
-			self::$id['pending']      => 'Please be patient while content loads.',
+			self::$id['donation_bar'] => self::$example_messages[ self::$id['donation_bar'] ],
+			self::$id['pending']      => self::$example_messages[ self::$id['pending'] ],
 			self::$id['button_text']  => '',
 		];
 		update_option( 'coil_messaging_settings_group', $settings_panel_messages );
@@ -212,7 +261,7 @@ class Test_Messaging_Settings extends WP_UnitTestCase {
 		// Testing removal of a deprecated message
 		set_theme_mod( self::$id['partially_gated_excerpt_message'], 'Partially gated excerpt' );
 
-		// Transferrng settings to the wp_options table
+		// Transferring settings to the wp_options table
 		Settings\transfer_customizer_message_settings();
 
 		// Creating an array of the messages that were retrieved from the wp_options table.
@@ -226,12 +275,12 @@ class Test_Messaging_Settings extends WP_UnitTestCase {
 		];
 
 		// Checking that all messages that were retrieved are correct
-		$this->assertSame( 'Coil promotion', $message[ self::$id['donation_bar'] ] );
+		$this->assertSame( self::$example_messages[ self::$id['donation_bar'] ], $message[ self::$id['donation_bar'] ] );
 		$this->assertSame( 'Loading content', $message[ self::$id['pending'] ] );
 		$this->assertSame( 'Fully gated', $message[ self::$id['fully_gated'] ] );
-		$this->assertSame( 'To keep reading, join Coil and install the browser extension. Visit coil.com for more information.', $message[ self::$id['partially_gated'] ] );
+		$this->assertSame( self::$defaults[ self::$id['partially_gated'] ], $message[ self::$id['partially_gated'] ] );
 		$this->assertSame( 'Learn More', $message[ self::$id['button_text'] ] );
-		$this->assertSame( 'https://coil.com/', $message[ self::$id['button_link'] ] );
+		$this->assertSame( self::$defaults[ self::$id['button_link'] ], $message[ self::$id['button_link'] ] );
 
 		// Checking that the theme_mod messages have been removed
 		$this->assertFalse( get_theme_mod( self::$id['donation_bar'] ) );
@@ -243,5 +292,27 @@ class Test_Messaging_Settings extends WP_UnitTestCase {
 		// Checking that deprecated message was removed
 		$this->assertFalse( get_theme_mod( self::$id['unverified'] ) );
 		$this->assertFalse( get_theme_mod( self::$id['partially_gated_excerpt_message'] ) );
+	}
+
+	/**
+	 * Check the special case in the transfer process where the unverified fully gated message replaces the unsupported fully gated message.
+	 * This happens when the unverified message has been customized and the unsupported message has not.
+	 *
+	 * @return void
+	 */
+	public function test_transferring_fully_gated_message() :  void {
+
+		// Adding custom messages to the theme_mod
+		set_theme_mod( self::$id['unverified'], 'Unable to verify' );
+
+		// Transferring the fully gated content message to the wp_options table
+		Settings\transfer_customizer_message_settings();
+
+		$retrieved_fully_gated_message = Admin\get_messaging_setting_or_default( self::$id['fully_gated'] );
+
+		// Checking that the unverified message has been transferred instead of using the unsupported default message
+		//$this->assertSame( 'Unable to verify', $retrieved_fully_gated_message );
+		// Checking that the theme_mod message was removed
+		$this->assertFalse( get_theme_mod( self::$id['unverified'] ) );
 	}
 }


### PR DESCRIPTION
Transfer of messages from the customizer now uses the 'unverified' message (when a user isn't logged in to their Coil account) as the Exclusive Post message IF the 'unsupported' message (when the browser extension is missing) hasn't been filled in in the customizer. The condition checking if the customizer is empty has also been corrected.