### PR TITLE
Sj taxonomy bug fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
             bash install.sh
             groupadd --gid 1000 node && useradd --uid 1000 --gid node -G sudo --shell /bin/bash --create-home node
             cd /var/www/html/wp-content/plugins/coil-wordpress-plugin
-            source ~/.nvm/nvm.sh && nvm install 12 && nvm use 12 && nvm install-latest-npm && npm install cypress && npx cypress run --project ./tests --config baseUrl="http://127.0.0.1:80/" --record --key=$CYPRESS_PROJECT_KEY
+            source ~/.nvm/nvm.sh && nvm install 12 && nvm use 12 && nvm install npm@8.3.2 && npm install cypress && npx cypress run --project ./tests --config baseUrl="http://127.0.0.1:80/" --record --key=$CYPRESS_PROJECT_KEY
 workflows:
   version: 2
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
             bash install.sh
             groupadd --gid 1000 node && useradd --uid 1000 --gid node -G sudo --shell /bin/bash --create-home node
             cd /var/www/html/wp-content/plugins/coil-wordpress-plugin
-            source ~/.nvm/nvm.sh && nvm install 12 && nvm use 12 && nvm install npm@8.3.2 && npm install cypress && npx cypress run --project ./tests --config baseUrl="http://127.0.0.1:80/" --record --key=$CYPRESS_PROJECT_KEY
+            source ~/.nvm/nvm.sh && nvm install 12 && nvm use 12 && nvm install npm && npm install cypress && npx cypress run --project ./tests --config baseUrl="http://127.0.0.1:80/" --record --key=$CYPRESS_PROJECT_KEY
 workflows:
   version: 2
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
             bash install.sh
             groupadd --gid 1000 node && useradd --uid 1000 --gid node -G sudo --shell /bin/bash --create-home node
             cd /var/www/html/wp-content/plugins/coil-wordpress-plugin
-            source ~/.nvm/nvm.sh && nvm install 12 && nvm use 12 && nvm install npm && npm install cypress && npx cypress run --project ./tests --config baseUrl="http://127.0.0.1:80/" --record --key=$CYPRESS_PROJECT_KEY
+            source ~/.nvm/nvm.sh && nvm install 12 && nvm use 12 && nvm install-latest-npm && npm install cypress && npx cypress run --project ./tests --config baseUrl="http://127.0.0.1:80/" --record --key=$CYPRESS_PROJECT_KEY
 workflows:
   version: 2
   test:

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -33,9 +33,16 @@ function maybe_save_post_metabox( int $post_id ) : void {
 	}
 
 	$post_monetization = sanitize_text_field( $_REQUEST['_coil_monetization_post_status'] ?? '' );
-	$post_visibility   = sanitize_text_field( $_REQUEST['_coil_visibility_post_status'] ?? '' );
 
-	if ( $post_monetization || $post_visibility ) {
+	if ( $post_monetization !== '' ) {
+		switch ( $post_monetization ) {
+			case 'monetized':
+				$post_visibility = sanitize_text_field( $_REQUEST['_coil_visibility_post_status'] ?? get_visibility_default() );
+				break;
+			default:
+				$post_visibility = get_visibility_default();
+				break;
+		}
 		Gating\set_post_status( $post_id, '_coil_monetization_post_status', $post_monetization );
 		Gating\set_post_status( $post_id, '_coil_visibility_post_status', $post_visibility );
 	} else {

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -64,9 +64,16 @@ function maybe_save_term_meta( int $term_id, int $tt_id, $taxonomy ) : void {
 	check_admin_referer( 'coil_term_gating_nonce_action', 'term_gating_nonce' );
 
 	$term_monetization = sanitize_text_field( $_REQUEST['_coil_monetization_term_status'] ?? '' );
-	$term_visibity     = sanitize_text_field( $_REQUEST['_coil_visibility_term_status'] ?? '' );
 
-	if ( $term_monetization && $term_visibity ) {
+	if ( $term_monetization !== '' ) {
+		switch ( $term_monetization ) {
+			case 'monetized':
+				$term_visibity = sanitize_text_field( $_REQUEST['_coil_visibility_term_status'] ?? get_visibility_default() );
+				break;
+			default:
+				$term_visibity = get_visibility_default();
+				break;
+		}
 		Gating\set_term_status( $term_id, '_coil_monetization_term_status', $term_monetization );
 		Gating\set_term_status( $term_id, '_coil_visibility_term_status', $term_visibity );
 	} else {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -142,7 +142,7 @@ function load_block_editor_assets() : void {
 	$monetization_default = isset( $monetization_settings[ get_current_screen()->post_type . '_monetization' ] ) ? $monetization_settings[ get_current_screen()->post_type . '_monetization' ] : 'default';
 	$visibility_settings  = get_option( 'coil_exclusive_settings_group' );
 	// If nothing has been saved in the wp_options table then visibility should default to public (In the menu visibility has no 'default' option).
-	$visibility_default = isset( $visibility_settings[ get_current_screen()->post_type . '_visibility' ] ) ? $visibility_settings[ get_current_screen()->post_type . '_visibility' ] : 'public';
+	$visibility_default = isset( $visibility_settings[ get_current_screen()->post_type . '_visibility' ] ) ? $visibility_settings[ get_current_screen()->post_type . '_visibility' ] : Admin\get_visibility_default();
 
 	wp_localize_script(
 		'coil-editor',
@@ -311,7 +311,7 @@ function add_body_class( $classes ) : array {
 		$coil_monetization_status = Gating\get_content_status( get_queried_object_id(), 'monetization' );
 		$classes[]                = sanitize_html_class( 'coil-' . $coil_monetization_status );
 		if ( ! $exclusive_content_enabled ) {
-			$coil_visibility_status = 'public';
+			$coil_visibility_status = Admin\get_visibility_default();
 		} else {
 			$coil_visibility_status = Gating\get_content_status( get_queried_object_id(), 'visibility' );
 		}

--- a/includes/settings/functions.php
+++ b/includes/settings/functions.php
@@ -222,7 +222,7 @@ function coil_general_settings_group_validation( $general_settings ) : array {
 
 		// Ensures that a post cannot default to be Not Monetized and Exclusive
 		if ( $final_settings[ $monetization_setting_key ] === 'not-monetized' && isset( $exclusive_settings[ $visibility_setting_key ] ) && $exclusive_settings[ $visibility_setting_key ] === 'exclusive' ) {
-			$exclusive_settings [ $visibility_setting_key ] = 'public';
+			$exclusive_settings [ $visibility_setting_key ] = Admin\get_visibility_default();
 			update_option( 'coil_exclusive_settings_group', $exclusive_settings );
 		}
 	}


### PR DESCRIPTION
I found If I set a tag as default and attach it to a post (which is set to default) then it shows up with the appropriate default. Then I change the category to exclusive and the post becomes exclusive as it should. But when I change the category back to default the post stays exclusive.

Fixed the bug and applied the same logic to saving post meta as well. Ensuring, during the saving process that visibility can only be exclusive if monetization has been selected.