### PR TITLE
Sj excerpt display fixes

### DIFF
--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -391,7 +391,16 @@ function get_exclusive_settings(): array {
 function is_exclusive_content_enabled() {
 	$exclusive_options   = get_exclusive_settings();
 	$exclusive_toggle_id = 'coil_exclusive_toggle';
-	return isset( $exclusive_options[ $exclusive_toggle_id ] ) ? $exclusive_options[ $exclusive_toggle_id ] : false;
+	return isset( $exclusive_options[ $exclusive_toggle_id ] ) ? $exclusive_options[ $exclusive_toggle_id ] : get_exclusive_content_enabled_default();
+}
+
+/**
+ * Provides the exclusive content toggle setting default
+ *
+ * @return bool The default is true
+ */
+function get_exclusive_content_enabled_default() {
+	return true;
 }
 
 /**

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -376,10 +376,7 @@ function get_exclusive_settings(): array {
 	$defaults = [ 'coil_content_container' => '.content-area .entry-content' ];
 
 	$exclusive_options = get_option( 'coil_exclusive_settings_group', [] );
-	if ( empty( $exclusive_options ) ) {
-		$exclusive_options = [ 'coil_content_container' => '.content-area .entry-content' ];
-	}
-	if ( ! isset( $exclusive_options['coil_content_container'] ) ) {
+	if ( empty( $exclusive_options ) || ! isset( $exclusive_options['coil_content_container'] ) ) {
 		$exclusive_options['coil_content_container'] = $defaults['coil_content_container'];
 	}
 

--- a/includes/settings/functions.php
+++ b/includes/settings/functions.php
@@ -354,7 +354,7 @@ function coil_button_settings_group_validation( $coil_button_settings ): array {
 	$checkbox_fields = [ 'coil_show_promotion_bar' ];
 
 	foreach ( $checkbox_fields as $field_name ) {
-		$final_settings[ $field_name ] = isset( $coil_button_settings[ $field_name ] ) ? true : false;
+		$final_settings[ $field_name ] = isset( $coil_button_settings[ $field_name ] ) && ( $coil_button_settings[ $field_name ] === 'on' || $coil_button_settings[ $field_name ] === true ) ? true : false;
 	}
 	return $final_settings;
 }
@@ -566,7 +566,7 @@ function coil_settings_enable_exclusive_toggle_render_callback() {
 				$checked_input = '';
 			}
 			echo sprintf(
-				'<label class="coil-checkbox" for="%1$s"><input type="%2$s" name="%3$s" id="%1$s"" %4$s /><span></span><i></i></label>',
+				'<label class="coil-checkbox" for="%1$s"><input type="%2$s" name="%3$s" id="%1$s" %4$s /><span></span><i></i></label>',
 				esc_attr( $exclusive_toggle_id ),
 				esc_attr( 'checkbox' ),
 				esc_attr( 'coil_exclusive_settings_group[' . $exclusive_toggle_id . ']' ),

--- a/includes/settings/functions.php
+++ b/includes/settings/functions.php
@@ -277,8 +277,7 @@ function coil_exclusive_settings_group_validation( $exclusive_settings ) : array
 
 		// Validates excerpt display settings
 		$excerpt_setting_key                    = $post_type->name . '_excerpt';
-		$final_settings[ $excerpt_setting_key ] = isset( $exclusive_settings[ $excerpt_setting_key ] ) ? true : false;
-
+		$final_settings[ $excerpt_setting_key ] = isset( $exclusive_settings[ $excerpt_setting_key ] ) && ( $exclusive_settings[ $excerpt_setting_key ] === 'on' || $exclusive_settings[ $excerpt_setting_key ] === true ) ? true : false;
 	}
 
 	// Validates all text input fields
@@ -333,13 +332,13 @@ function coil_exclusive_settings_group_validation( $exclusive_settings ) : array
 
 	// Validates all checkbox input fields
 	$checkbox_fields = [
-		'coil_message_font',
-		'coil_title_padlock',
-		'coil_exclusive_toggle',
+		'coil_message_font'     => Admin\get_paywall_appearance_defaults()['coil_message_font'],
+		'coil_title_padlock'    => Admin\get_exclusive_post_defaults()['coil_title_padlock'],
+		'coil_exclusive_toggle' => Admin\get_exclusive_content_enabled_default(),
 	];
 
-	foreach ( $checkbox_fields as $field_name ) {
-		$final_settings[ $field_name ] = isset( $exclusive_settings[ $field_name ] ) ? true : false;
+	foreach ( $checkbox_fields as $field_name => $field_default ) {
+		$final_settings[ $field_name ] = isset( $exclusive_settings[ $field_name ] ) && ( $exclusive_settings[ $field_name ] === 'on' || $exclusive_settings[ $field_name ] === true ) ? true : false;
 	}
 	return $final_settings;
 }
@@ -567,11 +566,10 @@ function coil_settings_enable_exclusive_toggle_render_callback() {
 				$checked_input = '';
 			}
 			echo sprintf(
-				'<label class="coil-checkbox" for="%1$s"><input type="%2$s" name="%3$s" id="%1$s" value="%4$b" %5$s /><span></span><i></i></label>',
+				'<label class="coil-checkbox" for="%1$s"><input type="%2$s" name="%3$s" id="%1$s"" %4$s /><span></span><i></i></label>',
 				esc_attr( $exclusive_toggle_id ),
 				esc_attr( 'checkbox' ),
 				esc_attr( 'coil_exclusive_settings_group[' . $exclusive_toggle_id . ']' ),
-				$value,
 				$checked_input
 			);
 			?>
@@ -768,13 +766,13 @@ function paywall_font_render_callback() {
 	}
 
 	echo sprintf(
-		'<label class="%6$s" for="%1$s"><input type="%3$s" name="%2$s" id="%1$s" %4$s /> <strong>%5$s</strong></label>',
+		'<label class="%1$s" for="%2$s"><input type="%3$s" name="%4$s" id="%2$s" %5$s /> <strong>%6$s</strong></label>',
+		esc_attr( 'coil-clear-left' ),
 		esc_attr( $font_input_id ),
-		esc_attr( 'coil_exclusive_settings_group[' . $font_input_id . ']' ),
 		esc_attr( 'checkbox' ),
+		esc_attr( 'coil_exclusive_settings_group[' . $font_input_id . ']' ),
 		$checked_input,
-		esc_html( 'Use theme font styles', 'coil-web-monetization' ),
-		esc_attr( 'coil-clear-left' )
+		esc_html( 'Use theme font styles', 'coil-web-monetization' )
 	);
 }
 
@@ -858,7 +856,6 @@ function coil_settings_exclusive_post_render_callback() {
  * @return void
 */
 function coil_padlock_display_checkbox_render_callback() {
-
 	/**
 	* Specify the default checked state for the input from
 	* any settings stored in the database. If the
@@ -871,21 +868,19 @@ function coil_padlock_display_checkbox_render_callback() {
 	if ( $value === true ) {
 		$checked_input = 'checked="checked"';
 	} else {
-		$checked_input = false;
-		$value         = false;
+		$checked_input = '';
 	}
 
 	printf(
-		'<input type="%s" name="%s" id="%s" value=%b %s>',
+		'<input type="%1$s" name="%2$s" id="%3$s" %4$s>',
 		esc_attr( 'checkbox' ),
 		esc_attr( 'coil_exclusive_settings_group[' . $padlock_input_id . ']' ),
 		esc_attr( $padlock_input_id ),
-		esc_attr( $value ),
 		$checked_input
 	);
 
 	printf(
-		'<label for="%s">%s</label>',
+		'<label for="%1$s">%2$s</label>',
 		esc_attr( $padlock_input_id ),
 		esc_html_e( 'Show padlock icon next to exclusive post titles.', 'coil-web-monetization' )
 	);
@@ -1307,23 +1302,31 @@ function render_generic_post_type_table( $settings_group, $column_names, $input_
 							} elseif ( $input_type === 'checkbox' ) {
 								if ( isset( $current_options[ $post_type->name . '_' . $value_id_suffix ] ) && $current_options[ $post_type->name . '_' . $value_id_suffix ] === true ) {
 									$checked_input = 'checked="true"';
-									$setting_key   = true;
 								} else {
-									$checked_input = false;
-									$setting_key   = false;
+									$checked_input = '';
 								}
 							}
 							?>
 							<td>
 								<?php
-								printf(
-									'<input type="%s" name="%s" id="%s" value="%s"%s />',
-									esc_attr( $input_type ),
-									esc_attr( $input_name ),
-									esc_attr( $input_id ),
-									esc_attr( $setting_key ),
-									$checked_input
-								);
+								if ( $input_type === 'checkbox' ) {
+									printf(
+										'<input type="%s" name="%s" id="%s" %s />',
+										esc_attr( $input_type ),
+										esc_attr( $input_name ),
+										esc_attr( $input_id ),
+										$checked_input
+									);
+								} else {
+									printf(
+										'<input type="%s" name="%s" id="%s" value="%s"%s />',
+										esc_attr( $input_type ),
+										esc_attr( $input_name ),
+										esc_attr( $input_id ),
+										esc_attr( $setting_key ),
+										$checked_input
+									);
+								}
 								?>
 							</td>
 							<?php

--- a/includes/transfers/functions.php
+++ b/includes/transfers/functions.php
@@ -57,7 +57,7 @@ function maybe_load_database_defaults() {
 		$excerpt_display_settings = [];
 		$post_type_options        = Coil\get_supported_post_types( 'objects' );
 
-		$excerpt_display_settings['coil_exclusive_toggle'] = true;
+		$exclusive_toggle_settings['coil_exclusive_toggle'] = Admin\get_exclusive_content_enabled_default();
 
 		// Set post visibility and excerpt display default for each post type
 		foreach ( $post_type_options as $post_type ) {
@@ -66,7 +66,7 @@ function maybe_load_database_defaults() {
 		}
 
 		// Merges all the sections together and updates the option group in the database.
-		$new_exclusive_settings = array_merge( $paywall_appearance_settings, $exclusive_post_settings, $post_visibility_settings, $excerpt_display_settings );
+		$new_exclusive_settings = array_merge( $paywall_appearance_settings, $exclusive_post_settings, $post_visibility_settings, $excerpt_display_settings, $exclusive_toggle_settings );
 		add_option( 'coil_exclusive_settings_group', $new_exclusive_settings );
 	}
 


### PR DESCRIPTION
Fixed bug where updating the coil_exclusive_options_group was saving unchecked checkboxes as checked because of inappropriate use of the isset function in the validation